### PR TITLE
Migrate to PHP 8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 *.sublime-*
 /about
 build
+/.*

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ composer.phar
 *.sublime-*
 /about
 build
-/.*
+.phpunit.cache
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
-
+  - 8.3
+  
 sudo: false
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 8.3
+  - 8.4
   
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,11 @@
     {
       "name": "Amine Ben hammou",
       "email": "webneat@gmail.com"
+    },
+    {
+      "name": "Wojtek Brozyna",
+      "email": "wojciech.brozyna@gmail.com",
+      "role": "Maintainer (fork)"
     }
   ],
   "autoload": {
@@ -16,9 +21,17 @@
     }
   },
   "require": {
-    "php": "^7.0"
+    "php": "^8.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.1"
+    "phpunit/phpunit": "^10.5",
+    "squizlabs/php_codesniffer": "^3.10",
+    "rector/rector": "^2.2"
+  },
+  "scripts": {
+    "run-tests": "vendor/bin/phpunit --display-deprecations --display-phpunit-deprecations",
+    "code-sniff": "vendor/bin/phpcs -d memory_limit=512M -p src tests examples --standard=PSR12",
+    "code-fix": "vendor/bin/phpcbf -d memory_limit=512M -p src tests examples --standard=PSR12",
+    "rector": "vendor/bin/rector process"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   },
   "require": {
-    "php": "^8.3"
+    "php": "^8.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5",
@@ -30,8 +30,8 @@
   },
   "scripts": {
     "run-tests": "vendor/bin/phpunit --display-deprecations --display-phpunit-deprecations",
-    "code-sniff": "vendor/bin/phpcs -d memory_limit=512M -p src tests examples --standard=PSR12",
-    "code-fix": "vendor/bin/phpcbf -d memory_limit=512M -p src tests examples --standard=PSR12",
+    "code-sniff": "vendor/bin/phpcs -d memory_limit=512M -p src examples --standard=PSR12",
+    "code-fix": "vendor/bin/phpcbf -d memory_limit=512M -p src examples --standard=PSR12",
     "rector": "vendor/bin/rector process"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7053ab8f544311b1eaa29a33785c47c1",
+    "content-hash": "8200faeb549faed88270bda5a1a98235",
     "packages": [],
     "packages-dev": [
         {
@@ -1875,7 +1875,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "^8.4"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1,89 +1,44 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c6441a892dd2c82114be7df9c92188b",
+    "content-hash": "7053ab8f544311b1eaa29a33785c47c1",
     "packages": [],
     "packages-dev": [
         {
-            "name": "doctrine/instantiator",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3,<8.0-DEV"
-            },
-            "require-dev": {
-                "athletic/athletic": "~0.1.8",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
                 }
@@ -93,7 +48,6 @@
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -101,32 +55,102 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
-            "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "name": "nikic/php-parser",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+            },
+            "time": "2025-10-21T19:32:17+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -156,24 +180,34 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -203,254 +237,105 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
-            },
+            "name": "phpstan/phpstan",
+            "version": "2.1.31",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.4|^8.0"
             },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
             },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
+            "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
+                "dev",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2017-06-03T08:32:36+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1|^2.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
                 },
                 {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
                 }
             ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2025-10-10T14:14:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.2",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8ed1902a57849e117b5651fc1a5c48110946c06b",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -465,7 +350,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -476,29 +361,43 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-03T12:40:43+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -513,7 +412,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -523,26 +422,108 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -564,32 +545,43 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -604,7 +596,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -613,69 +605,30 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.3.0",
+            "version": "10.5.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb"
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9501bab711403a1ab5b8378a8adb4ec3db3debdb",
-                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
                 "shasum": ""
             },
             "require": {
@@ -684,35 +637,30 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -720,10 +668,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.3.x-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -746,41 +697,119 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-04T05:20:39+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-28T12:04:46+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
+            "name": "rector/rector",
+            "version": "2.2.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "022038537838bc8a4e526af86c2d6e38eaeff7ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/022038537838bc8a4e526af86c2d6e38eaeff7ef",
+                "reference": "022038537838bc8a4e526af86c2d6e38eaeff7ef",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.26"
             },
             "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
             },
             "suggest": {
-                "ext-soap": "*"
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-29T15:46:12+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -795,42 +824,105 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
             ],
-            "time": "2017-08-03T14:08:16+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -850,34 +942,46 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.2",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a"
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0",
-                "sebastian/exporter": "^3.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -890,6 +994,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -901,45 +1009,65 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-08-03T07:14:59+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-07T05:25:07+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "2.0.1",
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -953,45 +1081,120 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1010,40 +1213,51 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1057,6 +1271,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1065,53 +1283,72 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1130,38 +1367,107 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1181,32 +1487,42 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1226,32 +1542,42 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1265,12 +1591,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1278,30 +1604,56 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
         },
         {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "name": "sebastian/type",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1316,34 +1668,45 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1364,27 +1727,116 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1404,66 +1856,27 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
+                    "url": "https://github.com/theseer",
+                    "type": "github"
                 }
             ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.0"
+        "php": "^8.3"
     },
-    "platform-dev": []
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  php83:
+    container_name: tarsana-syntax-dev
+    build: ./docker
+    working_dir: /app
+    volumes:
+      - ./:/app
+    # Run a script or just show the PHP version
+    command: bash -c "composer install"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  php83:
+  php84:
     container_name: tarsana-syntax-dev
     build: ./docker
     working_dir: /app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 # Install system dependencies needed for Composer, Git, and building extensions
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM php:8.3-cli
+
+# Install system dependencies needed for Composer, Git, and building extensions
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    unzip \
+    zip \
+    gzip \
+    libzip-dev \
+    libonig-dev \
+    libxml2-dev \
+    && docker-php-ext-install zip mbstring xml \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+# Enable Xdebug coverage mode
+ENV XDEBUG_MODE=coverage
+
+# Install the latest Composer (v2)
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && rm composer-setup.php
+
+# Make /app a "safe" Git directory
+RUN git config --global --add safe.directory /app
+
+# Verify installation
+RUN composer --version && git --version
+
+WORKDIR /app
+COPY . /app

--- a/examples/long-example.php
+++ b/examples/long-example.php
@@ -1,4 +1,5 @@
 <?php
+
 require __DIR__ . '/../vendor/autoload.php';
 
 use Tarsana\Syntax\Factory as S;

--- a/examples/short-example.php
+++ b/examples/short-example.php
@@ -1,4 +1,5 @@
 <?php
+
 require __DIR__ . '/../vendor/autoload.php';
 
 use Tarsana\Syntax\Factory as S;
@@ -8,7 +9,7 @@ $repo = "{name: string, stars:number}";
 // a line consists of a first and last names, optional number of followers, and repos, separated by space. The repos are separated by ","
 $line = "{first_name, last_name, followers: (number: 0), repos: ([{$repo}]:[]) | }";
 // a document is a list of lines separated by PHP_EOL
-$document = "[{$line}|".PHP_EOL."]";
+$document = "[{$line}|" . PHP_EOL . "]";
 
 // Now we make the syntax object
 $documentSyntax = S::syntax()->parse($document);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
->
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <testsuites>
-        <testsuite name="Tarsana Syntax Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache" failOnRisky="true" failOnWarning="true">
+  <testsuites>
+    <testsuite name="Tarsana Syntax Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/examples',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withPhpSets()
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,6 @@ return RectorConfig::configure()
         __DIR__ . '/tests',
     ])
     ->withPhpSets()
-    ->withTypeCoverageLevel(0)
-    ->withDeadCodeLevel(0)
-    ->withCodeQualityLevel(0);
+    ->withTypeCoverageLevel(10)
+    ->withDeadCodeLevel(10)
+    ->withCodeQualityLevel(10);

--- a/src/ArraySyntax.php
+++ b/src/ArraySyntax.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax;
+<?php
+
+namespace Tarsana\Syntax;
 
 use Tarsana\Syntax\Exceptions\DumpException;
 use Tarsana\Syntax\Exceptions\ParseException;
@@ -7,8 +9,8 @@ use Tarsana\Syntax\Syntax;
 /**
  * Represents an array of values with the same syntax.
  */
-class ArraySyntax extends Syntax {
-
+class ArraySyntax extends Syntax
+{
     const DEFAULT_SEPARATOR = ',';
     const ERROR = 'Not an array';
 
@@ -31,10 +33,12 @@ class ArraySyntax extends Syntax {
      */
     public function __construct(Syntax $syntax = null, string $separator = null)
     {
-        if($syntax === null)
+        if ($syntax === null) {
             $syntax = Factory::string();
-        if ($separator === null || $separator == '')
+        }
+        if ($separator === null || $separator == '') {
             $separator = self::DEFAULT_SEPARATOR;
+        }
 
         $this->syntax = $syntax;
         $this->separator = $separator;
@@ -46,7 +50,7 @@ class ArraySyntax extends Syntax {
      * @param  Tarsana\Syntax\Syntax $value
      * @return Tarsana\Syntax\Syntax
      */
-    public function syntax(Syntax $value = null) : Syntax
+    public function syntax(Syntax $value = null): Syntax
     {
         if (null === $value) {
             return $this->syntax;
@@ -75,7 +79,7 @@ class ArraySyntax extends Syntax {
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return "Array of ({$this->syntax}) separated by '{$this->separator}'";
     }
@@ -89,7 +93,7 @@ class ArraySyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\ParseException
      */
-    public function parse(string $text) : array
+    public function parse(string $text): array
     {
         $index = 0;
         $items = Text::split($text, $this->separator);
@@ -97,7 +101,7 @@ class ArraySyntax extends Syntax {
         try {
             foreach ($items as $item) {
                 $array[] = $this->syntax->parse($item);
-                $index += strlen($item) + 1;
+                $index += strlen((string) $item) + 1;
             }
         } catch (ParseException $e) {
             $extra = [
@@ -105,8 +109,13 @@ class ArraySyntax extends Syntax {
                 'item' => $item,
                 'position' => $e->position()
             ];
-            throw new ParseException($this, $text, $index + $e->position(),
-                "Unable to parse the item '{$item}'", $extra, $e
+            throw new ParseException(
+                $this,
+                $text,
+                $index + $e->position(),
+                "Unable to parse the item '{$item}'",
+                $extra,
+                $e
             );
         }
 
@@ -122,10 +131,11 @@ class ArraySyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\DumpException
      */
-    public function dump($values) : string
+    public function dump($values): string
     {
-        if (! is_array($values))
+        if (! is_array($values)) {
             throw new DumpException($this, $values, self::ERROR);
+        }
         $items = [];
         $index = 0;
         try {
@@ -139,5 +149,4 @@ class ArraySyntax extends Syntax {
 
         return Text::join($items, $this->separator);
     }
-
 }

--- a/src/ArraySyntax.php
+++ b/src/ArraySyntax.php
@@ -11,8 +11,8 @@ use Tarsana\Syntax\Syntax;
  */
 class ArraySyntax extends Syntax
 {
-    const DEFAULT_SEPARATOR = ',';
-    const ERROR = 'Not an array';
+    public const DEFAULT_SEPARATOR = ',';
+    public const ERROR = 'Not an array';
 
     /**
      * The string that separates items of the array.
@@ -31,7 +31,7 @@ class ArraySyntax extends Syntax
     /**
      * Creates a new instance of ArraySyntax.
      */
-    public function __construct(Syntax $syntax = null, string $separator = null)
+    public function __construct(?Syntax $syntax = null, ?string $separator = null)
     {
         if ($syntax === null) {
             $syntax = Factory::string();
@@ -50,7 +50,7 @@ class ArraySyntax extends Syntax
      * @param  Tarsana\Syntax\Syntax $value
      * @return Tarsana\Syntax\Syntax
      */
-    public function syntax(Syntax $value = null): Syntax
+    public function syntax(?Syntax $value = null): Syntax
     {
         if (null === $value) {
             return $this->syntax;
@@ -65,7 +65,7 @@ class ArraySyntax extends Syntax
      * @param  string $value
      * @return self|string
      */
-    public function separator(string $value = null)
+    public function separator(?string $value = null)
     {
         if (null === $value) {
             return $this->separator;

--- a/src/BooleanSyntax.php
+++ b/src/BooleanSyntax.php
@@ -10,11 +10,11 @@ use Tarsana\Syntax\Exceptions\DumpException;
  */
 class BooleanSyntax extends Syntax
 {
-    const TRUE_VALUES  = ['true', 'yes', 'y'];
-    const FALSE_VALUES = ['false', 'no', 'n'];
+    public const TRUE_VALUES  = ['true', 'yes', 'y'];
+    public const FALSE_VALUES = ['false', 'no', 'n'];
 
-    const PARSE_ERROR = 'Boolean value should be one of "yes", "no", "y", "n", "true", "false"';
-    const DUMP_ERROR  = 'Not a boolean';
+    public const PARSE_ERROR = 'Boolean value should be one of "yes", "no", "y", "n", "true", "false"';
+    public const DUMP_ERROR  = 'Not a boolean';
 
     protected static $instance = null;
 

--- a/src/BooleanSyntax.php
+++ b/src/BooleanSyntax.php
@@ -16,7 +16,7 @@ class BooleanSyntax extends Syntax
     public const PARSE_ERROR = 'Boolean value should be one of "yes", "no", "y", "n", "true", "false"';
     public const DUMP_ERROR  = 'Not a boolean';
 
-    protected static $instance = null;
+    protected static $instance;
 
     /**
      * Returns the BooleanSyntax instance.

--- a/src/BooleanSyntax.php
+++ b/src/BooleanSyntax.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax;
+<?php
+
+namespace Tarsana\Syntax;
 
 use Tarsana\Syntax\Exceptions\ParseException;
 use Tarsana\Syntax\Exceptions\DumpException;
@@ -6,8 +8,8 @@ use Tarsana\Syntax\Exceptions\DumpException;
 /**
  * Represents a boolean.
  */
-class BooleanSyntax extends Syntax {
-
+class BooleanSyntax extends Syntax
+{
     const TRUE_VALUES  = ['true', 'yes', 'y'];
     const FALSE_VALUES = ['false', 'no', 'n'];
 
@@ -21,14 +23,17 @@ class BooleanSyntax extends Syntax {
      *
      * @return Tarsana\Syntax\BooleanSyntax
      */
-    public static function instance() : BooleanSyntax
+    public static function instance(): BooleanSyntax
     {
-        if (self::$instance === null)
-            self::$instance = new BooleanSyntax;
+        if (self::$instance === null) {
+            self::$instance = new BooleanSyntax();
+        }
         return self::$instance;
     }
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * Parses the `$text` and returns the
@@ -39,11 +44,12 @@ class BooleanSyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\ParseException
      */
-    public function parse(string $text) : bool
+    public function parse(string $text): bool
     {
         $lower = strtolower($text);
-        if (! in_array($lower, array_merge(self::TRUE_VALUES, self::FALSE_VALUES)))
+        if (! in_array($lower, array_merge(self::TRUE_VALUES, self::FALSE_VALUES))) {
             throw new ParseException($this, $text, 0, self::PARSE_ERROR);
+        }
         return in_array($lower, self::TRUE_VALUES);
     }
 
@@ -55,10 +61,11 @@ class BooleanSyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\DumpException
      */
-    public function dump($value) : string
+    public function dump($value): string
     {
-        if (! is_bool($value))
+        if (! is_bool($value)) {
             throw new DumpException($this, $value, self::DUMP_ERROR);
+        }
 
         return $value ? 'true' : 'false';
     }
@@ -68,9 +75,8 @@ class BooleanSyntax extends Syntax {
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'Boolean';
     }
-
 }

--- a/src/Exceptions/DumpException.php
+++ b/src/Exceptions/DumpException.php
@@ -1,9 +1,11 @@
-<?php namespace Tarsana\Syntax\Exceptions;
+<?php
+
+namespace Tarsana\Syntax\Exceptions;
 
 use Tarsana\Syntax\Syntax;
 
-class DumpException extends Exception {
-
+class DumpException extends Exception
+{
     public function __construct(Syntax $syntax, $input, string $message, array $extra = [], $previous = null)
     {
         parent::__construct(

--- a/src/Exceptions/Exception.php
+++ b/src/Exceptions/Exception.php
@@ -1,24 +1,22 @@
-<?php namespace Tarsana\Syntax\Exceptions;
+<?php
+
+namespace Tarsana\Syntax\Exceptions;
 
 use Tarsana\Syntax\Syntax;
 
-class Exception extends \Exception {
-
+class Exception extends \Exception
+{
     protected $syntax;
-    protected $input;
     protected $extra;
-    protected $previous;
 
-    public function __construct(Syntax $syntax, $input, string $message, array $extra, $previous)
+    public function __construct(Syntax $syntax, protected $input, string $message, array $extra, protected $previous)
     {
         $this->syntax = $syntax;
-        $this->input = $input;
         $this->message = $message;
         $this->extra = $extra;
-        $this->previous = $previous;
     }
 
-    public function syntax() : Syntax
+    public function syntax(): Syntax
     {
         return $this->syntax;
     }
@@ -28,7 +26,7 @@ class Exception extends \Exception {
         return $this->input;
     }
 
-    public function message() : string
+    public function message(): string
     {
         return $this->message;
     }
@@ -42,5 +40,4 @@ class Exception extends \Exception {
     {
         return $this->extra;
     }
-
 }

--- a/src/Exceptions/ParseException.php
+++ b/src/Exceptions/ParseException.php
@@ -1,9 +1,11 @@
-<?php namespace Tarsana\Syntax\Exceptions;
+<?php
+
+namespace Tarsana\Syntax\Exceptions;
 
 use Tarsana\Syntax\Syntax;
 
-class ParseException extends Exception {
-
+class ParseException extends Exception
+{
     protected $position;
 
     public function __construct(Syntax $syntax, string $input, int $position, string $message, array $extra = [], $previous = null)
@@ -18,9 +20,8 @@ class ParseException extends Exception {
         $this->position = $position;
     }
 
-    public function position() : int
+    public function position(): int
     {
         return $this->position;
     }
-
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,40 +1,41 @@
-<?php namespace Tarsana\Syntax;
+<?php
 
-class Factory {
+namespace Tarsana\Syntax;
 
-    public static function string() : StringSyntax
+class Factory
+{
+    public static function string(): StringSyntax
     {
         return StringSyntax::instance();
     }
 
-    public static function boolean() : BooleanSyntax
+    public static function boolean(): BooleanSyntax
     {
         return BooleanSyntax::instance();
     }
 
-    public static function number() : NumberSyntax
+    public static function number(): NumberSyntax
     {
         return NumberSyntax::instance();
     }
 
-    public static function array(Syntax $syntax = null, string $separator = null) : ArraySyntax
+    public static function array(Syntax $syntax = null, string $separator = null): ArraySyntax
     {
         return new ArraySyntax($syntax, $separator);
     }
 
-    public static function object(array $fields, string $separator = null) : ObjectSyntax
+    public static function object(array $fields, string $separator = null): ObjectSyntax
     {
         return new ObjectSyntax($fields, $separator);
     }
 
-    public static function optional(Syntax $syntax, $default) : OptionalSyntax
+    public static function optional(Syntax $syntax, $default): OptionalSyntax
     {
         return new OptionalSyntax($syntax, $default);
     }
 
-    public static function syntax() : SyntaxSyntax
+    public static function syntax(): SyntaxSyntax
     {
         return SyntaxSyntax::instance();
     }
-
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -19,12 +19,12 @@ class Factory
         return NumberSyntax::instance();
     }
 
-    public static function array(Syntax $syntax = null, string $separator = null): ArraySyntax
+    public static function array(?Syntax $syntax = null, ?string $separator = null): ArraySyntax
     {
         return new ArraySyntax($syntax, $separator);
     }
 
-    public static function object(array $fields, string $separator = null): ObjectSyntax
+    public static function object(array $fields, ?string $separator = null): ObjectSyntax
     {
         return new ObjectSyntax($fields, $separator);
     }

--- a/src/NumberSyntax.php
+++ b/src/NumberSyntax.php
@@ -12,7 +12,7 @@ class NumberSyntax extends Syntax
 {
     public const ERROR = 'Not a numeric value';
 
-    protected static $instance = null;
+    protected static $instance;
 
     /**
      * Returns the NumberSyntax instance.

--- a/src/NumberSyntax.php
+++ b/src/NumberSyntax.php
@@ -10,7 +10,7 @@ use Tarsana\Syntax\Exceptions\ParseException;
  */
 class NumberSyntax extends Syntax
 {
-    const ERROR = 'Not a numeric value';
+    public const ERROR = 'Not a numeric value';
 
     protected static $instance = null;
 

--- a/src/NumberSyntax.php
+++ b/src/NumberSyntax.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax;
+<?php
+
+namespace Tarsana\Syntax;
 
 use Tarsana\Syntax\Exceptions\DumpException;
 use Tarsana\Syntax\Exceptions\ParseException;
@@ -6,8 +8,8 @@ use Tarsana\Syntax\Exceptions\ParseException;
 /**
  * Represents a string.
  */
-class NumberSyntax extends Syntax {
-
+class NumberSyntax extends Syntax
+{
     const ERROR = 'Not a numeric value';
 
     protected static $instance = null;
@@ -17,14 +19,17 @@ class NumberSyntax extends Syntax {
      *
      * @return Tarsana\Syntax\NumberSyntax
      */
-    public static function instance() : NumberSyntax
+    public static function instance(): NumberSyntax
     {
-        if (self::$instance === null)
-            self::$instance = new NumberSyntax;
+        if (self::$instance === null) {
+            self::$instance = new NumberSyntax();
+        }
         return self::$instance;
     }
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * Parses the `$text` and returns the
@@ -37,8 +42,9 @@ class NumberSyntax extends Syntax {
      */
     public function parse(string $text)
     {
-        if (! is_numeric($text))
+        if (! is_numeric($text)) {
             throw new ParseException($this, $text, 0, self::ERROR);
+        }
         return $text + 0;
     }
 
@@ -51,12 +57,13 @@ class NumberSyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\DumpException
      */
-    public function dump($value) : string
+    public function dump($value): string
     {
-        if (! is_numeric($value))
+        if (! is_numeric($value)) {
             throw new DumpException($this, $value, self::ERROR);
+        }
 
-        return ''. $value;
+        return '' . $value;
     }
 
     /**
@@ -64,7 +71,7 @@ class NumberSyntax extends Syntax {
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'Number';
     }

--- a/src/ObjectSyntax.php
+++ b/src/ObjectSyntax.php
@@ -1,7 +1,8 @@
-<?php namespace Tarsana\Syntax;
+<?php
+
+namespace Tarsana\Syntax;
 
 use Tarsana\Syntax\Exceptions\DumpException;
-use Tarsana\Syntax\Exceptions\Exception;
 use Tarsana\Syntax\Exceptions\ParseException;
 use Tarsana\Syntax\OptionalSyntax;
 use Tarsana\Syntax\Syntax;
@@ -9,8 +10,8 @@ use Tarsana\Syntax\Syntax;
 /**
  * Represents an couple of values with different syntaxes.
  */
-class ObjectSyntax extends Syntax {
-
+class ObjectSyntax extends Syntax
+{
     const DEFAULT_SEPARATOR = ':';
     const MISSING_FIELD     = 'missing-field';
     const INVALID_FIELD     = 'invalid-field';
@@ -42,15 +43,17 @@ class ObjectSyntax extends Syntax {
     /**
      * Creates a new instance of ObjectSyntax.
      *
-     * @param array $fields Associative array specifying the fields of the object.
+     * @param array  $fields    Associative array specifying the fields of the object.
      * @param string $separator The string that separates items of the array.
      */
     public function __construct(array $fields, string $separator = null)
     {
-        if (empty($fields))
+        if (empty($fields)) {
             throw new \InvalidArgumentException('ObjectSyntax should have at least one field');
-        if ($separator === null ||  $separator == '')
+        }
+        if ($separator === null ||  $separator == '') {
             $separator = self::DEFAULT_SEPARATOR;
+        }
 
         $this->fields = $fields;
         $this->separator = $separator;
@@ -90,7 +93,7 @@ class ObjectSyntax extends Syntax {
     /**
      * Setter and getter of a specific field.
      *
-     * @param  string $name
+     * @param  string                     $name
      * @param  Tarsana\Syntax\Syntax|null $value
      * @return Tarsana\Syntax\Syntax|self
      *
@@ -123,7 +126,7 @@ class ObjectSyntax extends Syntax {
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         $fields = [];
         foreach ($this->fields as $name => $syntax) {
@@ -169,7 +172,7 @@ class ObjectSyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\ParseException
      */
-    public function parse(string $text) : \stdClass
+    public function parse(string $text): \stdClass
     {
         $items = Text::split($text, $this->separator);
         $itemsCount = count($items);
@@ -186,22 +189,23 @@ class ObjectSyntax extends Syntax {
                 $syntax = $this->fields[$names[$nameIndex]];
                 $this->values[$names[$nameIndex]]->value = $syntax->parse($items[$itemIndex]);
                 $this->values[$names[$nameIndex]]->error = null;
-                $index += strlen($items[$itemIndex]) + $separatorLength;
-                $nameIndex ++;
-                $itemIndex ++;
+                $index += strlen((string) $items[$itemIndex]) + $separatorLength;
+                $nameIndex++;
+                $itemIndex++;
                 if ($syntax instanceof OptionalSyntax && !$syntax->success()) {
-                    $itemIndex --;
+                    $itemIndex--;
                 }
             }
             // if items are left
-            if ($itemIndex < $itemsCount)
+            if ($itemIndex < $itemsCount) {
                 $itemsLeft = true;
+            }
             // if fields are left
             while ($nameIndex < $namesCount) {
                 $syntax = $this->fields[$names[$nameIndex]];
                 $this->values[$names[$nameIndex]]->value = $syntax->parse('');
                 $this->values[$names[$nameIndex]]->error = null;
-                $nameIndex ++;
+                $nameIndex++;
             }
         } catch (ParseException $e) {
             if ($itemIndex < $itemsCount) {
@@ -229,13 +233,16 @@ class ObjectSyntax extends Syntax {
                 'type'  => 'additional-items',
                 'items' => array_slice($items, $itemIndex)
             ];
-            throw new ParseException($this, $text, $index - $separatorLength,
-                "Additional items with no corresponding fields", $extra);
+            throw new ParseException(
+                $this,
+                $text,
+                $index - $separatorLength,
+                "Additional items with no corresponding fields",
+                $extra
+            );
         }
 
-        return (object) array_map(function(\stdClass $field) {
-            return $field->value;
-        }, $this->values);
+        return (object) array_map(fn(\stdClass $field) => $field->value, $this->values);
     }
 
     /**
@@ -247,7 +254,7 @@ class ObjectSyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\DumpException
      */
-    public function dump($value) : string
+    public function dump($value): string
     {
         $value = (array) $value;
         $result = [];
@@ -266,10 +273,10 @@ class ObjectSyntax extends Syntax {
             throw new DumpException($this, $value, "Unable to dump the field '{$current}'", [], $e);
         }
 
-        if ($missingField)
+        if ($missingField) {
             throw new DumpException($this, $value, "Missing field '{$name}'");
+        }
 
         return Text::join($result, $this->separator);
     }
-
 }

--- a/src/ObjectSyntax.php
+++ b/src/ObjectSyntax.php
@@ -12,10 +12,10 @@ use Tarsana\Syntax\Syntax;
  */
 class ObjectSyntax extends Syntax
 {
-    const DEFAULT_SEPARATOR = ':';
-    const MISSING_FIELD     = 'missing-field';
-    const INVALID_FIELD     = 'invalid-field';
-    const ADDITIONAL_ITEMS  = 'additional-items';
+    public const DEFAULT_SEPARATOR = ':';
+    public const MISSING_FIELD     = 'missing-field';
+    public const INVALID_FIELD     = 'invalid-field';
+    public const ADDITIONAL_ITEMS  = 'additional-items';
 
     /**
      * The string that separates items of the object.
@@ -46,7 +46,7 @@ class ObjectSyntax extends Syntax
      * @param array  $fields    Associative array specifying the fields of the object.
      * @param string $separator The string that separates items of the array.
      */
-    public function __construct(array $fields, string $separator = null)
+    public function __construct(array $fields, ?string $separator = null)
     {
         if (empty($fields)) {
             throw new \InvalidArgumentException('ObjectSyntax should have at least one field');
@@ -99,7 +99,7 @@ class ObjectSyntax extends Syntax
      *
      * @throws InvalidArgumentException
      */
-    public function field(string $name, Syntax $value = null)
+    public function field(string $name, ?Syntax $value = null)
     {
         if ($value === null) {
             $names = explode('.', $name);

--- a/src/OptionalSyntax.php
+++ b/src/OptionalSyntax.php
@@ -46,7 +46,7 @@ class OptionalSyntax extends Syntax
      * @param  Tarsana\Syntax\Syntax $value
      * @return Tarsana\Syntax\Syntax
      */
-    public function syntax(Syntax $value = null): Syntax
+    public function syntax(?Syntax $value = null): Syntax
     {
         if (null === $value) {
             return $this->syntax;

--- a/src/OptionalSyntax.php
+++ b/src/OptionalSyntax.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax;
+<?php
+
+namespace Tarsana\Syntax;
 
 use Tarsana\Syntax\Exceptions\ParseException;
 use Tarsana\Syntax\Syntax;
@@ -6,21 +8,14 @@ use Tarsana\Syntax\Syntax;
 /**
  * Represents a syntax with a default value.
  */
-class OptionalSyntax extends Syntax {
-
+class OptionalSyntax extends Syntax
+{
     /**
      * The syntax.
      *
      * @var Tarsana\Syntax\Syntax
      */
     protected $syntax;
-
-    /**
-     * The default value.
-     *
-     * @var mixed
-     */
-    protected $default;
 
     /**
      * Tells if the last parse operation
@@ -36,10 +31,13 @@ class OptionalSyntax extends Syntax {
      * @param Tarsana\Syntax\Syntax $syntax
      * @param mixed $default
      */
-    public function __construct(Syntax $syntax, $default)
-    {
+    public function __construct(
+        Syntax $syntax, /**
+         * The default value.
+         */
+        protected $default
+    ) {
         $this->syntax  = $syntax;
-        $this->default = $default;
     }
 
     /**
@@ -48,7 +46,7 @@ class OptionalSyntax extends Syntax {
      * @param  Tarsana\Syntax\Syntax $value
      * @return Tarsana\Syntax\Syntax
      */
-    public function syntax(Syntax $value = null) : Syntax
+    public function syntax(Syntax $value = null): Syntax
     {
         if (null === $value) {
             return $this->syntax;
@@ -85,7 +83,8 @@ class OptionalSyntax extends Syntax {
      *
      * @return  bool
      */
-    public function success() {
+    public function success()
+    {
         return $this->success;
     }
 
@@ -94,7 +93,7 @@ class OptionalSyntax extends Syntax {
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return "Optional {$this->syntax}";
     }
@@ -112,7 +111,7 @@ class OptionalSyntax extends Syntax {
         try {
             $result = $this->syntax->parse($text);
             $this->success = true;
-        } catch (ParseException $e) {
+        } catch (ParseException) {
             $result = $this->default;
             $this->success = false;
         }
@@ -128,9 +127,8 @@ class OptionalSyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\DumpException
      */
-    public function dump($value) : string
+    public function dump($value): string
     {
         return $this->syntax->dump($value);
     }
-
 }

--- a/src/StringSyntax.php
+++ b/src/StringSyntax.php
@@ -13,7 +13,7 @@ class StringSyntax extends Syntax
     public const ERROR = 'Not a string value';
     public const NO_EMPTY = 'String should not be empty';
 
-    protected static $instance = null;
+    protected static $instance;
 
     /**
      * Returns the StringSyntax instance.

--- a/src/StringSyntax.php
+++ b/src/StringSyntax.php
@@ -10,8 +10,8 @@ use Tarsana\Syntax\Exceptions\ParseException;
  */
 class StringSyntax extends Syntax
 {
-    const ERROR = 'Not a string value';
-    const NO_EMPTY = 'String should not be empty';
+    public const ERROR = 'Not a string value';
+    public const NO_EMPTY = 'String should not be empty';
 
     protected static $instance = null;
 

--- a/src/StringSyntax.php
+++ b/src/StringSyntax.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax;
+<?php
+
+namespace Tarsana\Syntax;
 
 use Tarsana\Syntax\Exceptions\DumpException;
 use Tarsana\Syntax\Exceptions\ParseException;
@@ -6,8 +8,8 @@ use Tarsana\Syntax\Exceptions\ParseException;
 /**
  * Represents a string.
  */
-class StringSyntax extends Syntax {
-
+class StringSyntax extends Syntax
+{
     const ERROR = 'Not a string value';
     const NO_EMPTY = 'String should not be empty';
 
@@ -18,14 +20,17 @@ class StringSyntax extends Syntax {
      *
      * @return Tarsana\Syntax\StringSyntax
      */
-    public static function instance() : StringSyntax
+    public static function instance(): StringSyntax
     {
-        if (self::$instance === null)
-            self::$instance = new StringSyntax;
+        if (self::$instance === null) {
+            self::$instance = new StringSyntax();
+        }
         return self::$instance;
     }
 
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * Returns the given string.
@@ -33,10 +38,11 @@ class StringSyntax extends Syntax {
      * @param  string $text
      * @return string
      */
-    public function parse(string $text) : string
+    public function parse(string $text): string
     {
-        if ($text === '')
+        if ($text === '') {
             throw new ParseException($this, $text, 0, self::NO_EMPTY);
+        }
         return $text;
     }
 
@@ -48,10 +54,11 @@ class StringSyntax extends Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\DumpException
      */
-    public function dump($value) : string
+    public function dump($value): string
     {
-        if (! is_string($value))
+        if (! is_string($value)) {
             throw new DumpException($this, $value, self::ERROR);
+        }
         return $value;
     }
 
@@ -60,7 +67,7 @@ class StringSyntax extends Syntax {
      *
      * @return string
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'String';
     }

--- a/src/Syntax.php
+++ b/src/Syntax.php
@@ -1,12 +1,12 @@
-<?php namespace Tarsana\Syntax;
+<?php
 
-use Tarsana\Syntax\Result\Result;
+namespace Tarsana\Syntax;
 
 /**
  * All syntaxes should inherit from this class.
  */
-abstract class Syntax {
-
+abstract class Syntax implements \Stringable
+{
     /**
      * Parses the `$text` and returns the
      * result or throws a `ParseException`.
@@ -27,12 +27,12 @@ abstract class Syntax {
      *
      * @throws Tarsana\Syntax\Exceptions\DumpException
      */
-    abstract public function dump($value) : string;
+    abstract public function dump($value): string;
 
     /**
      * Returns the string representation of the syntax.
      *
      * @return string
      */
-    abstract public function __toString() : string;
+    abstract public function __toString(): string;
 }

--- a/src/SyntaxSyntax.php
+++ b/src/SyntaxSyntax.php
@@ -15,7 +15,7 @@ use Tarsana\Syntax\StringSyntax;
  */
 class SyntaxSyntax extends Syntax
 {
-    protected static $instance = null;
+    protected static $instance;
 
     protected $objectSyntax;
     protected $optionalSyntax;

--- a/src/SyntaxSyntax.php
+++ b/src/SyntaxSyntax.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax;
+<?php
+
+namespace Tarsana\Syntax;
 
 use Tarsana\Syntax\BooleanSyntax;
 use Tarsana\Syntax\Exceptions\DumpException;
@@ -11,79 +13,98 @@ use Tarsana\Syntax\StringSyntax;
 /**
  * This syntax generates a Syntax from a string.
  */
-class SyntaxSyntax extends Syntax {
-
+class SyntaxSyntax extends Syntax
+{
     protected static $instance = null;
 
     protected $objectSyntax;
     protected $optionalSyntax;
     protected $arraySyntax;
 
-    public static function instance() : SyntaxSyntax
+    public static function instance(): SyntaxSyntax
     {
-        if (self::$instance === null)
-            self::$instance = new SyntaxSyntax;
+        if (self::$instance === null) {
+            self::$instance = new SyntaxSyntax();
+        }
         return self::$instance;
     }
 
 
-    private function __construct() {
+    private function __construct()
+    {
         // (type:default)
-        $this->optionalSyntax = S::object([
+        $this->optionalSyntax = S::object(
+            [
             'type'    => S::string(),
             'default' => S::string()
-        ]);
+            ]
+        );
 
         // [type|separator]
-        $this->arraySyntax = S::object([
+        $this->arraySyntax = S::object(
+            [
             'type' => S::optional(S::string(), 'string'),
             'separator' => S::optional(S::string(), ArraySyntax::DEFAULT_SEPARATOR)
-        ])->separator('|');
+            ]
+        )->separator('|');
 
         // {name:type, name:type, ...|separator}
-        $this->objectSyntax = S::object([
-            'fields' => S::array(S::object([
-                'name' => S::string(),
-                'type' => S::optional(S::string(), 'string')
-            ])),
+        $this->objectSyntax = S::object(
+            [
+            'fields' => S::array(
+                S::object(
+                    [
+                    'name' => S::string(),
+                    'type' => S::optional(S::string(), 'string')
+                    ]
+                )
+            ),
             'separator' => S::optional(S::string(), ObjectSyntax::DEFAULT_SEPARATOR)
-        ])->separator('|');
+            ]
+        )->separator('|');
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'Syntax';
     }
 
-    public function parse(string $text) : Syntax
+    public function parse(string $text): Syntax
     {
         $text = trim($text);
 
-        if ($text === '' || $text === 'string')
+        if ($text === '' || $text === 'string') {
             return S::string();
+        }
 
-        if ($text === 'number')
+        if ($text === 'number') {
             return S::number();
+        }
 
-        if ($text === 'boolean')
+        if ($text === 'boolean') {
             return S::boolean();
+        }
 
-        if ($text === 'syntax')
+        if ($text === 'syntax') {
             return S::syntax();
+        }
 
         $length = strlen($text);
         if ($length >= 2) {
             $wrappers = substr($text, 0, 1) . substr($text, -1);
             $inner    = substr($text, 1, strlen($text) - 2);
 
-            if ($wrappers == '[]')
+            if ($wrappers == '[]') {
                 return $this->parseArray($inner);
+            }
 
-            if ($wrappers == '()')
+            if ($wrappers == '()') {
                 return $this->parseOptional($inner);
+            }
 
-            if ($wrappers == '{}')
+            if ($wrappers == '{}') {
                 return $this->parseObject($inner);
+            }
         }
 
         throw new ParseException($this, $text, 0, "Invalid syntax");
@@ -94,17 +115,18 @@ class SyntaxSyntax extends Syntax {
         return json_decode($value);
     }
 
-    public function encode($value) : string
+    public function encode($value): string
     {
         return json_encode($value);
     }
 
-    protected function parseOptional(string $text) : OptionalSyntax
+    protected function parseOptional(string $text): OptionalSyntax
     {
         $optional = $this->optionalSyntax->parse($text);
 
-        if ($optional->type == 'string')
+        if ($optional->type == 'string') {
             $optional->default = "\"{$optional->default}\"";
+        }
 
         return S::optional(
             $this->parse($optional->type),
@@ -112,48 +134,53 @@ class SyntaxSyntax extends Syntax {
         );
     }
 
-    protected function parseArray(string $text) : ArraySyntax
+    protected function parseArray(string $text): ArraySyntax
     {
         $array = $this->arraySyntax->parse($text);
 
         return S::array($this->parse($array->type), $array->separator);
     }
 
-    protected function parseObject(string $text) : ObjectSyntax
+    protected function parseObject(string $text): ObjectSyntax
     {
         $object = $this->objectSyntax->parse($text);
 
         $fields = [];
         foreach ($object->fields as $field) {
-            $fields[trim($field->name)] = $this->parse($field->type);
+            $fields[trim((string) $field->name)] = $this->parse($field->type);
         }
 
         return S::object($fields, $object->separator);
     }
 
-    public function dump($value) : string
+    public function dump($value): string
     {
-        if (! ($value instanceof Syntax))
+        if (! ($value instanceof Syntax)) {
             throw new DumpException($this, $value, "Not a syntax");
+        }
 
-        if ($value instanceof StringSyntax)
+        if ($value instanceof StringSyntax) {
             return 'string';
+        }
 
-        if ($value instanceof NumberSyntax)
+        if ($value instanceof NumberSyntax) {
             return 'number';
+        }
 
-        if ($value instanceof BooleanSyntax)
+        if ($value instanceof BooleanSyntax) {
             return 'boolean';
+        }
 
-        if ($value instanceof SyntaxSyntax)
+        if ($value instanceof SyntaxSyntax) {
             return 'syntax';
+        }
 
         if ($value instanceof ArraySyntax) {
             $array = [
                 'type' => $this->dump($value->syntax()),
                 'separator' => $value->separator()
             ];
-            return '['.$this->arraySyntax->dump($array).']';
+            return '[' . $this->arraySyntax->dump($array) . ']';
         }
 
         if ($value instanceof OptionalSyntax) {
@@ -161,12 +188,12 @@ class SyntaxSyntax extends Syntax {
                 'type' => $this->dump($value->syntax()),
                 'default' => $this->encode($value->getDefault())
             ];
-            return '('.$this->optionalSyntax->dump($optional).')';
+            return '(' . $this->optionalSyntax->dump($optional) . ')';
         }
 
         if ($value instanceof ObjectSyntax) {
             $fields = [];
-            foreach($value->fields() as $name => $syntax) {
+            foreach ($value->fields() as $name => $syntax) {
                 $fields[] = (object) [
                     'name' => $name,
                     'type' => $this->dump($syntax)
@@ -174,7 +201,7 @@ class SyntaxSyntax extends Syntax {
             }
             $object = ['fields' => $fields, 'separator' => $value->separator()];
 
-            return '{'.$this->objectSyntax->dump($object).'}';
+            return '{' . $this->objectSyntax->dump($object) . '}';
         }
 
         throw new DumpException($this, $value, "Unknown syntax");

--- a/src/Text.php
+++ b/src/Text.php
@@ -1,8 +1,10 @@
-<?php namespace Tarsana\Syntax;
+<?php
 
-class Text {
+namespace Tarsana\Syntax;
 
-    public static function split(string $text, string $separator, string $surrounders = '""[](){}', string $wrappers = '""') : array
+class Text
+{
+    public static function split(string $text, string $separator, string $surrounders = '""[](){}', string $wrappers = '""'): array
     {
         // Let's assume some values to understand how this function works
         // surrounders = '""{}()'
@@ -19,11 +21,13 @@ class Text {
             'total'    => 0   // the total number of needed closings
         ];
         foreach (str_split($surrounders) as $key => $char) {
-            $counters['values'][$key / 2] = 0;
-            if ($key % 2 == 0)
-                $counters['openings'][$char] = $key / 2;
-            else
-                $counters['closings'][$char] = $key / 2;
+            $index = intdiv($key, 2);
+            $counters['values'][$index] = 0;
+            if ($key % 2 == 0) {
+                $counters['openings'][$char] = $index;
+            } else {
+                $counters['closings'][$char] = $index;
+            }
         }
         // $counters = [
         //   'values'   => [0, 0, 0],
@@ -50,27 +54,28 @@ class Text {
                     $value = $counters['values'][$counters['openings'][$c]];
                     if ($value == 0) {
                         $counters['values'][$counters['openings'][$c]] = 1;
-                        $counters['total'] ++;
+                        $counters['total']++;
                     } else {
                         $counters['values'][$counters['openings'][$c]] = 0;
-                        $counters['total'] --;
+                        $counters['total']--;
                     }
                 } else {
                     if ($isOpening) {
-                        $counters['values'][$counters['openings'][$c]] ++;
-                        $counters['total'] ++;
+                        $counters['values'][$counters['openings'][$c]]++;
+                        $counters['total']++;
                     }
                     if ($isClosing) {
-                        $counters['values'][$counters['closings'][$c]] --;
-                        $counters['total'] --;
+                        $counters['values'][$counters['closings'][$c]]--;
+                        $counters['total']--;
                     }
                 }
                 $buffer .= $c;
-                $index ++;
+                $index++;
             }
         }
-        if ($buffer != '')
+        if ($buffer != '') {
             $result[] = self::unwrap($buffer, $wrappers);
+        }
 
         return $result;
     }
@@ -80,21 +85,22 @@ class Text {
      * ('(Hey)', '()') => 'Hey'
      * ('(Hey)', '""()') => 'Hey'
      */
-    public static function unwrap(string $text, string $wrappers) : string
+    public static function unwrap(string $text, string $wrappers): string
     {
         $size = strlen($wrappers);
         for ($i = 0; $i < $size; $i += 2) {
-            if (substr($text, 0, 1) == substr($wrappers, $i, 1)
-               && substr($text, -1) == substr($wrappers, $i + 1, 1))
+            if (
+                substr($text, 0, 1) == substr($wrappers, $i, 1)
+                && substr($text, -1) == substr($wrappers, $i + 1, 1)
+            ) {
                 return substr($text, 1, strlen($text) - 2);
+            }
         }
         return $text;
     }
 
-    public static function join(array $items, string $separator) : string
+    public static function join(array $items, string $separator): string
     {
-        return implode($separator, array_map(function(string $item) use($separator) {
-            return (strpos($item, $separator) !== false) ? "\"{$item}\"" : $item;
-        }, $items));
+        return implode($separator, array_map(fn(string $item) => (str_contains($item, $separator)) ? "\"{$item}\"" : $item, $items));
     }
 }

--- a/src/Text.php
+++ b/src/Text.php
@@ -101,6 +101,6 @@ class Text
 
     public static function join(array $items, string $separator): string
     {
-        return implode($separator, array_map(fn(string $item) => (str_contains($item, $separator)) ? "\"{$item}\"" : $item, $items));
+        return implode($separator, array_map(fn(string $item): string => (str_contains($item, $separator)) ? "\"{$item}\"" : $item, $items));
     }
 }

--- a/tests/ArraySyntaxTest.php
+++ b/tests/ArraySyntaxTest.php
@@ -1,54 +1,72 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\ArraySyntax;
 use Tarsana\Syntax\Factory as S;
 use Tarsana\Syntax\NumberSyntax;
 use Tarsana\Syntax\StringSyntax;
 
-class ArraySyntaxTest extends TestCase {
-
+class ArraySyntaxTest extends TestCase
+{
     public function test_getters_and_setters()
     {
         $syntax = S::array()
             ->separator('/')
             ->syntax(S::number());
 
-        $this->assertEquals('/', $syntax->separator());
+        $this->assertEqualsCompat('/', $syntax->separator());
         $this->assertTrue($syntax->syntax() instanceof NumberSyntax);
     }
 
-    public function test_parse() {
-        $syntax = new ArraySyntax;
-        $this->assertParse($syntax, [
+    public function test_parse()
+    {
+        $syntax = new ArraySyntax();
+        $this->assertParse(
+            $syntax,
+            [
             ['input' => 'foo,BAR,baZ', 'result' => ['foo', 'BAR', 'baZ']],
             ['input' => 'foo:BAR,baZ', 'result' => ['foo:BAR', 'baZ']],
             ['input' => 'foo,"bar","baz,lorem",ipsum",yo"', 'result' => ['foo', 'bar', 'baz,lorem', 'ipsum",yo"']]
-        ]);
+            ]
+        );
 
         $syntax = new ArraySyntax(S::string(), ':');
-        $this->assertParse($syntax, [
+        $this->assertParse(
+            $syntax,
+            [
             ['input' => 'foo,BAR,baZ', 'result' => ['foo,BAR,baZ']],
             ['input' => 'foo:BAR,baZ', 'result' => ['foo', 'BAR,baZ']],
-        ]);
+            ]
+        );
 
         $syntax = new ArraySyntax(S::number(), '--');
-        $this->assertParse($syntax, [
+        $this->assertParse(
+            $syntax,
+            [
             ['input' => '5---6.5--20.4', 'result' => [5, -6.5, 20.4]],
-        ]);
+            ]
+        );
 
         $syntax = new ArraySyntax(S::number());
-        $this->assertParse($syntax, [
+        $this->assertParse(
+            $syntax,
+            [
             ['input' => '5,-6.5,20.4', 'result' => [5, -6.5, 20.4]],
             ['input' => '5,nan,20.4', 'errors' => [
                 "Error while parsing '5,nan,20.4' as Array of (Number) separated by ',' at character 2: Unable to parse the item 'nan'",
-                "Error while parsing 'nan' as Number at character 0: ". NumberSyntax::ERROR
+                "Error while parsing 'nan' as Number at character 0: " . NumberSyntax::ERROR
             ]],
-        ]);
+            ]
+        );
     }
 
-    public function test_dump() {
-        $syntax = new ArraySyntax;
-        $this->assertDump($syntax, [
+    public function test_dump()
+    {
+        $syntax = new ArraySyntax();
+        $this->assertDump(
+            $syntax,
+            [
             ['input' => ['foo','bar','baz'], 'result' => 'foo,bar,baz'],
             ['input' => 'foo', 'errors' => [
                 "Error while dumping some input as Array of (String) separated by ',': " . ArraySyntax::ERROR
@@ -57,11 +75,14 @@ class ArraySyntaxTest extends TestCase {
                 "Error while dumping some input as Array of (String) separated by ',': Unable to dump item at key 1",
                 "Error while dumping some input as String: " . StringSyntax::ERROR
             ]]
-        ]);
+            ]
+        );
         $syntax = new ArraySyntax(S::string(), ':');
-        $this->assertDump($syntax, [
+        $this->assertDump(
+            $syntax,
+            [
             ['input' => ['foo','bar','baz'], 'result' => 'foo:bar:baz'],
-        ]);
+            ]
+        );
     }
-
 }

--- a/tests/ArraySyntaxTest.php
+++ b/tests/ArraySyntaxTest.php
@@ -9,7 +9,7 @@ use Tarsana\Syntax\StringSyntax;
 
 class ArraySyntaxTest extends TestCase
 {
-    public function test_getters_and_setters()
+    public function test_getters_and_setters(): void
     {
         $syntax = S::array()
             ->separator('/')
@@ -19,7 +19,7 @@ class ArraySyntaxTest extends TestCase
         $this->assertTrue($syntax->syntax() instanceof NumberSyntax);
     }
 
-    public function test_parse()
+    public function test_parse(): void
     {
         $syntax = new ArraySyntax();
         $this->assertParse(
@@ -61,7 +61,7 @@ class ArraySyntaxTest extends TestCase
         );
     }
 
-    public function test_dump()
+    public function test_dump(): void
     {
         $syntax = new ArraySyntax();
         $this->assertDump(

--- a/tests/BooleanSyntaxTest.php
+++ b/tests/BooleanSyntaxTest.php
@@ -1,28 +1,38 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\BooleanSyntax;
 use Tarsana\Syntax\Factory as S;
 use Tarsana\Syntax\UnitTests\TestCase;
 
-class BooleanSyntaxTest extends TestCase {
-
-    public function test_parse() {
-        $this->assertParse(S::boolean(), [
+class BooleanSyntaxTest extends TestCase
+{
+    public function test_parse()
+    {
+        $this->assertParse(
+            S::boolean(),
+            [
             ['input' => ['true', 'yes', 'TRue', 'yeS', 'Y'], 'result' => true],
             ['input' => ['false', 'no', 'No', 'N'], 'result' => false],
             ['input'  => 'wrong boolean', 'errors' => [
                 "Error while parsing 'wrong boolean' as Boolean at character 0: " . BooleanSyntax::PARSE_ERROR
             ]]
-        ]);
+            ]
+        );
     }
 
-    public function test_dump() {
-        $this->assertDump(S::boolean(), [
+    public function test_dump()
+    {
+        $this->assertDump(
+            S::boolean(),
+            [
             ['input'  => true, 'result' => 'true'],
             ['input'   => false, 'result' => 'false'],
             ['input'   => [15, 'string'], 'errors'  => [
                 'Error while dumping some input as Boolean: ' . BooleanSyntax::DUMP_ERROR
             ]]
-        ]);
+            ]
+        );
     }
 }

--- a/tests/BooleanSyntaxTest.php
+++ b/tests/BooleanSyntaxTest.php
@@ -8,7 +8,7 @@ use Tarsana\Syntax\UnitTests\TestCase;
 
 class BooleanSyntaxTest extends TestCase
 {
-    public function test_parse()
+    public function test_parse(): void
     {
         $this->assertParse(
             S::boolean(),
@@ -22,7 +22,7 @@ class BooleanSyntaxTest extends TestCase
         );
     }
 
-    public function test_dump()
+    public function test_dump(): void
     {
         $this->assertDump(
             S::boolean(),

--- a/tests/Debugger.php
+++ b/tests/Debugger.php
@@ -29,7 +29,7 @@ class Debugger extends Syntax
             $syntax->syntax(new Debugger($syntax->syntax()));
         }
         if ($syntax instanceof ObjectSyntax) {
-            $syntax->fields(array_map(fn($s) => new Debugger($s), $syntax->fields()));
+            $syntax->fields(array_map(fn($s): \Debugger => new Debugger($s), $syntax->fields()));
         }
         $this->syntax = $syntax;
     }

--- a/tests/Debugger.php
+++ b/tests/Debugger.php
@@ -7,8 +7,8 @@ use Tarsana\Syntax\ObjectSyntax;
 use Tarsana\Syntax\OptionalSyntax;
 use Tarsana\Syntax\Syntax;
 
-class Debugger extends Syntax {
-
+class Debugger extends Syntax
+{
     protected static $level = 0;
 
     protected $syntax;
@@ -29,9 +29,7 @@ class Debugger extends Syntax {
             $syntax->syntax(new Debugger($syntax->syntax()));
         }
         if ($syntax instanceof ObjectSyntax) {
-            $syntax->fields(array_map(function($s) {
-                return new Debugger($s);
-            }, $syntax->fields()));
+            $syntax->fields(array_map(fn($s) => new Debugger($s), $syntax->fields()));
         }
         $this->syntax = $syntax;
     }
@@ -44,39 +42,39 @@ class Debugger extends Syntax {
     public function parse(string $text)
     {
         self::log("Parsing '{$text}' as {$this->syntax}\n");
-        self::$level ++;
+        self::$level++;
         try {
             $result = $this->syntax->parse($text);
-            self::$level --;
+            self::$level--;
             if ($this->syntax instanceof OptionalSyntax) {
                 self::log("Optional Success: " . $this->syntax->success());
             }
             self::log("Success: " . json_encode($result));
             return $result;
         } catch (ParseException $e) {
-            self::$level --;
+            self::$level--;
             self::log("Failure: " . $e->message());
             throw $e;
         }
     }
 
-    public function dump($value) : string
+    public function dump($value): string
     {
-        self::log("Dumping '". json_encode($value) . "' as {$this->syntax}\n");
-        self::$level ++;
+        self::log("Dumping '" . json_encode($value) . "' as {$this->syntax}\n");
+        self::$level++;
         try {
             $result = $this->syntax->dump($value);
-            self::$level --;
+            self::$level--;
             self::log("Success: " . $result);
             return $result;
         } catch (DumpException $e) {
-            self::$level --;
+            self::$level--;
             self::log("Failure: " . $e->message());
             throw $e;
         }
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return "{$this->syntax}";
     }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\ArraySyntax;
 use Tarsana\Syntax\BooleanSyntax;
@@ -9,57 +11,63 @@ use Tarsana\Syntax\OptionalSyntax;
 use Tarsana\Syntax\StringSyntax;
 use Tarsana\Syntax\SyntaxSyntax;
 
-class FactoryTest extends TestCase {
-
-    public function test_string() {
+class FactoryTest extends TestCase
+{
+    public function test_string()
+    {
         $syntax = S::string();
         $this->assertTrue($syntax instanceof StringSyntax);
     }
 
-    public function test_boolean() {
+    public function test_boolean()
+    {
         $syntax = S::boolean();
         $this->assertTrue($syntax instanceof BooleanSyntax);
     }
 
-    public function test_number() {
+    public function test_number()
+    {
         $syntax = S::number();
         $this->assertTrue($syntax instanceof NumberSyntax);
     }
 
-    public function test_array() {
+    public function test_array()
+    {
         $syntax = S::array();
         $this->assertTrue($syntax instanceof ArraySyntax);
         $this->assertTrue($syntax->syntax() instanceof StringSyntax);
-        $this->assertEquals(ArraySyntax::DEFAULT_SEPARATOR, $syntax->separator());
+        $this->assertEqualsCompat(ArraySyntax::DEFAULT_SEPARATOR, $syntax->separator());
 
         $syntax = S::array(S::number());
         $this->assertTrue($syntax instanceof ArraySyntax);
         $this->assertTrue($syntax->syntax() instanceof NumberSyntax);
-        $this->assertEquals(ArraySyntax::DEFAULT_SEPARATOR, $syntax->separator());
+        $this->assertEqualsCompat(ArraySyntax::DEFAULT_SEPARATOR, $syntax->separator());
 
         $syntax = S::array(S::number(), '|');
         $this->assertTrue($syntax instanceof ArraySyntax);
         $this->assertTrue($syntax->syntax() instanceof NumberSyntax);
-        $this->assertEquals('|', $syntax->separator());
+        $this->assertEqualsCompat('|', $syntax->separator());
     }
 
-    public function test_object() {
+    public function test_object()
+    {
         $syntax = S::object(['name' => S::string()]);
         $this->assertTrue($syntax instanceof ObjectSyntax);
         $this->assertTrue($syntax->field('name') instanceof StringSyntax);
-        $this->assertEquals(ObjectSyntax::DEFAULT_SEPARATOR, $syntax->separator());
+        $this->assertEqualsCompat(ObjectSyntax::DEFAULT_SEPARATOR, $syntax->separator());
     }
 
-    public function test_optional() {
+    public function test_optional()
+    {
         $syntax = S::optional(StringSyntax::instance(), 'None');
         $this->assertTrue($syntax instanceof OptionalSyntax);
         $this->assertTrue($syntax->syntax() instanceof StringSyntax);
-        $this->assertEquals('None', $syntax->getDefault());
+        $this->assertEqualsCompat('None', $syntax->getDefault());
     }
 
-    public function test_syntax() {
+    public function test_syntax()
+    {
         $syntax = S::syntax();
         $this->assertTrue($syntax instanceof SyntaxSyntax);
     }
-
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -13,25 +13,25 @@ use Tarsana\Syntax\SyntaxSyntax;
 
 class FactoryTest extends TestCase
 {
-    public function test_string()
+    public function test_string(): void
     {
         $syntax = S::string();
         $this->assertTrue($syntax instanceof StringSyntax);
     }
 
-    public function test_boolean()
+    public function test_boolean(): void
     {
         $syntax = S::boolean();
         $this->assertTrue($syntax instanceof BooleanSyntax);
     }
 
-    public function test_number()
+    public function test_number(): void
     {
         $syntax = S::number();
         $this->assertTrue($syntax instanceof NumberSyntax);
     }
 
-    public function test_array()
+    public function test_array(): void
     {
         $syntax = S::array();
         $this->assertTrue($syntax instanceof ArraySyntax);
@@ -49,7 +49,7 @@ class FactoryTest extends TestCase
         $this->assertEqualsCompat('|', $syntax->separator());
     }
 
-    public function test_object()
+    public function test_object(): void
     {
         $syntax = S::object(['name' => S::string()]);
         $this->assertTrue($syntax instanceof ObjectSyntax);
@@ -57,7 +57,7 @@ class FactoryTest extends TestCase
         $this->assertEqualsCompat(ObjectSyntax::DEFAULT_SEPARATOR, $syntax->separator());
     }
 
-    public function test_optional()
+    public function test_optional(): void
     {
         $syntax = S::optional(StringSyntax::instance(), 'None');
         $this->assertTrue($syntax instanceof OptionalSyntax);
@@ -65,7 +65,7 @@ class FactoryTest extends TestCase
         $this->assertEqualsCompat('None', $syntax->getDefault());
     }
 
-    public function test_syntax()
+    public function test_syntax(): void
     {
         $syntax = S::syntax();
         $this->assertTrue($syntax instanceof SyntaxSyntax);

--- a/tests/NumberSyntaxTest.php
+++ b/tests/NumberSyntaxTest.php
@@ -1,30 +1,39 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\Factory as S;
 use Tarsana\Syntax\NumberSyntax;
 
-class NumberSyntaxTest extends TestCase {
-
-    public function test_parse() {
-        $this->assertParse(S::number(), [
+class NumberSyntaxTest extends TestCase
+{
+    public function test_parse()
+    {
+        $this->assertParse(
+            S::number(),
+            [
             ['input' => '12', 'result' => 12],
             ['input' => '0.12', 'result' => 0.12],
             ['input' => '-0.20', 'result' => -0.2],
             ['input' => 't56', 'errors' => [
                 'Error while parsing \'t56\' as Number at character 0: ' . NumberSyntax::ERROR
             ]],
-        ]);
+            ]
+        );
     }
 
-    public function test_dump() {
-        $this->assertDump(S::number(), [
+    public function test_dump()
+    {
+        $this->assertDump(
+            S::number(),
+            [
             ['input' => 12, 'result' => '12'],
             ['input' => 0.12, 'result' => '0.12'],
             ['input' => -0.2, 'result' => '-0.2'],
             ['input' => 'nan', 'errors' => [
                 'Error while dumping some input as Number: ' . NumberSyntax::ERROR
             ]],
-        ]);
+            ]
+        );
     }
-
 }

--- a/tests/NumberSyntaxTest.php
+++ b/tests/NumberSyntaxTest.php
@@ -7,7 +7,7 @@ use Tarsana\Syntax\NumberSyntax;
 
 class NumberSyntaxTest extends TestCase
 {
-    public function test_parse()
+    public function test_parse(): void
     {
         $this->assertParse(
             S::number(),
@@ -22,7 +22,7 @@ class NumberSyntaxTest extends TestCase
         );
     }
 
-    public function test_dump()
+    public function test_dump(): void
     {
         $this->assertDump(
             S::number(),

--- a/tests/ObjectSyntaxTest.php
+++ b/tests/ObjectSyntaxTest.php
@@ -13,7 +13,7 @@ class ObjectSyntaxTest extends TestCase
 {
     public function test_getters_and_setters()
     {
-        $syntax = (new ObjectSyntax(['name' => S::array()], '|'))
+        $syntax = new ObjectSyntax(['name' => S::array()], '|')
             ->fields(['name' => S::string()])
             ->field('age', S::number());
 

--- a/tests/ObjectSyntaxTest.php
+++ b/tests/ObjectSyntaxTest.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\ArraySyntax;
 use Tarsana\Syntax\BooleanSyntax;
@@ -7,8 +9,8 @@ use Tarsana\Syntax\NumberSyntax;
 use Tarsana\Syntax\ObjectSyntax;
 use Tarsana\Syntax\StringSyntax;
 
-class ObjectSyntaxTest extends TestCase {
-
+class ObjectSyntaxTest extends TestCase
+{
     public function test_getters_and_setters()
     {
         $syntax = (new ObjectSyntax(['name' => S::array()], '|'))
@@ -16,44 +18,49 @@ class ObjectSyntaxTest extends TestCase {
             ->field('age', S::number());
 
         $fields = $syntax->fields();
-        $this->assertEquals('|', $syntax->separator());
-        $this->assertEquals(2, count($fields));
+        $this->assertEqualsCompat('|', $syntax->separator());
+        $this->assertEqualsCompat(2, count($fields));
         $this->assertTrue($syntax->field('name') instanceof StringSyntax);
-        $this->assertTrue( $syntax->field('age') instanceof NumberSyntax);
+        $this->assertTrue($syntax->field('age') instanceof NumberSyntax);
     }
 
     public function test_get_nested_fields()
     {
-        $syntax = S::object([
+        $syntax = S::object(
+            [
             'name' => S::string(),
-            'repos' => S::array(S::object([
-                'name' => S::string(),
-                'stars' => S::number(),
-            ])),
-            'profile' => S::object([
+            'repos' => S::array(
+                S::object(
+                    [
+                    'name' => S::string(),
+                    'stars' => S::number(),
+                    ]
+                )
+            ),
+            'profile' => S::object(
+                [
                 'active' => S::boolean(),
                 'balance' => S::number()
-            ])
-        ]);
+                ]
+            )
+            ]
+        );
 
         $this->assertTrue($syntax->field('repos') instanceof ArraySyntax);
         $this->assertTrue($syntax->field('repos.stars') instanceof NumberSyntax);
         $this->assertTrue($syntax->field('profile.active') instanceof BooleanSyntax);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function test_construct_without_fields()
+    public function test_construct_without_fields(): void
     {
+        $this->expectException(\InvalidArgumentException::class);
         new ObjectSyntax([]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function test_get_unknown_field()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $syntax = S::object(['name' => S::string()])
             ->separator('|')
             ->field('age', S::number());
@@ -61,26 +68,34 @@ class ObjectSyntaxTest extends TestCase {
         $syntax->field('account');
     }
 
-    public function test_to_string() {
-        $syntax = S::object([
+    public function test_to_string()
+    {
+        $syntax = S::object(
+            [
             'name' => S::string(),
             'age' => S::number(),
             'is_programmer' => S::boolean(),
             'friends' => S::array()
-        ]);
-        $this->assertEquals("Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by ':'", "{$syntax}");
+            ]
+        );
+        $this->assertEqualsCompat("Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by ':'", "{$syntax}");
     }
 
-    public function test_parse_all_fields_are_required() {
+    public function test_parse_all_fields_are_required()
+    {
         // Parsing all required fields
-        $syntax = S::object([
+        $syntax = S::object(
+            [
             'name' => S::string(),
             'age' => S::number(),
             'is_programmer' => S::boolean(),
             'friends' => S::array()
-        ]);
+            ]
+        );
 
-        $this->assertParse($syntax, [[
+        $this->assertParse(
+            $syntax,
+            [[
             'input'  => 'Foo:76:no:Bar,Baz',
             'result' => (object) [
                 'name' => 'Foo',
@@ -88,7 +103,7 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => false,
                 'friends' => ['Bar', 'Baz']
             ]
-        ], [
+            ], [
             'input'  => '"Foo:Bar:Baz":76:no:"Bar,Baz",lorem',
             'result' => (object) [
                 'name' => 'Foo:Bar:Baz',
@@ -96,22 +111,25 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => false,
                 'friends' => ['Bar,Baz', 'lorem']
             ]
-        ], [
+            ], [
             'input'  => 'Foo:76::Bar,Baz',
             'errors' => [
                 "Error while parsing 'Foo:76::Bar,Baz' as Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by ':' at character 7: Unable to parse the item '' for field 'is_programmer'",
                 "Error while parsing '' as Boolean at character 0: " . BooleanSyntax::PARSE_ERROR
             ]
-        ], [
+            ], [
             'input'  => 'Foo:76:false:Bar,Baz:additional',
             'errors' => [
                 "Error while parsing 'Foo:76:false:Bar,Baz:additional' as Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by ':' at character 20: Additional items with no corresponding fields"
             ]
-        ]]);
+            ]]
+        );
 
         // Changing the separator
         $syntax->separator('||');
-        $this->assertParse($syntax, [[
+        $this->assertParse(
+            $syntax,
+            [[
             'input'  => 'Foo||76||no||Bar,Baz',
             'result' => (object) [
                 'name' => 'Foo',
@@ -119,25 +137,31 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => false,
                 'friends' => ['Bar', 'Baz']
             ]
-        ], [
+            ], [
             'input'  => 'Foo||76||||Bar,Baz',
             'errors' => [
                 "Error while parsing 'Foo||76||||Bar,Baz' as Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by '||' at character 9: Unable to parse the item '' for field 'is_programmer'",
                 "Error while parsing '' as Boolean at character 0: " . BooleanSyntax::PARSE_ERROR
             ]
-        ]]);
+            ]]
+        );
     }
 
-    public function test_parse_all_fields_are_optional() {
+    public function test_parse_all_fields_are_optional()
+    {
         // Optional Fields
-        $syntax = S::object([
+        $syntax = S::object(
+            [
             'name' => S::optional(S::string(), 'Unknown'),
             'age' => S::optional(S::number(), 21),
             'is_programmer' => S::optional(S::boolean(), false),
             'friends' => S::optional(S::array(), [])
-        ]);
+            ]
+        );
 
-        $this->assertParse($syntax, [[
+        $this->assertParse(
+            $syntax,
+            [[
             'input'  => 'Foo:76:no:Bar,Baz',
             'result' => (object) [
                 'name' => 'Foo',
@@ -145,7 +169,7 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => false,
                 'friends' => ['Bar', 'Baz']
             ]
-        ], [
+            ], [
             'input'  => '',
             'result' => (object) [
                 'name' => 'Unknown',
@@ -153,7 +177,7 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => false,
                 'friends' => []
             ]
-        ], [
+            ], [
             'input'  => 'Me:yes',
             'result' => (object) [
                 'name' => 'Me',
@@ -161,7 +185,7 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => true,
                 'friends' => []
             ]
-        ], [
+            ], [
             'input'  => '27:23:yes',
             'result' => (object) [
                 'name' => '27',
@@ -169,7 +193,7 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => true,
                 'friends' => []
             ]
-        ], [
+            ], [
             'input'  => 'Me:code',
             'result' => (object) [
                 'name' => 'Me',
@@ -177,18 +201,24 @@ class ObjectSyntaxTest extends TestCase {
                 'is_programmer' => false,
                 'friends' => ['code']
             ]
-        ]]);
+            ]]
+        );
     }
 
-    public function test_parse_with_optional_fields() {
-        $syntax = S::object([
+    public function test_parse_with_optional_fields()
+    {
+        $syntax = S::object(
+            [
             'name' => S::string(),
             'is_programmer' => S::optional(S::boolean(), false),
             'age' => S::number(),
             'friends' => S::optional(S::array(), [])
-        ]);
+            ]
+        );
 
-        $this->assertParse($syntax, [[
+        $this->assertParse(
+            $syntax,
+            [[
             'input'  => 'Foo:76:Bar,Baz',
             'result' => (object) [
                 'name' => 'Foo',
@@ -196,7 +226,7 @@ class ObjectSyntaxTest extends TestCase {
                 'age' => 76,
                 'friends' => ['Bar', 'Baz']
             ]
-        ], [
+            ], [
             'input'  => 'Foo:yes:76',
             'result' => (object) [
                 'name' => 'Foo',
@@ -204,29 +234,35 @@ class ObjectSyntaxTest extends TestCase {
                 'age' => 76,
                 'friends' => []
             ]
-        ], [
+            ], [
             'input'  => 'Foo:yes:Bar,Baz',
             'errors' => [
                 "Error while parsing 'Foo:yes:Bar,Baz' as Object {name: String, is_programmer: Optional Boolean, age: Number, friends: Optional Array of (String) separated by ','} separated by ':' at character 8: Unable to parse the item 'Bar,Baz' for field 'age'",
                 "Error while parsing 'Bar,Baz' as Number at character 0: " . NumberSyntax::ERROR
             ]
-        ], [
+            ], [
             'input'  => 'Foo:yes',
             'errors' => [
                 "Error while parsing 'Foo:yes' as Object {name: String, is_programmer: Optional Boolean, age: Number, friends: Optional Array of (String) separated by ','} separated by ':' at character 8: No item left for field 'age'"
             ]
-        ]]);
+            ]]
+        );
     }
 
-    public function test_dump() {
-        $syntax = S::object([
+    public function test_dump()
+    {
+        $syntax = S::object(
+            [
             'name' => S::string(),
             'age' => S::number(),
             'is_programmer' => S::boolean(),
             'friends' => S::array()
-        ]);
+            ]
+        );
 
-        $this->assertDump($syntax, [[
+        $this->assertDump(
+            $syntax,
+            [[
             'input'  => (object) [
                 'name' => 'Foo',
                 'age'  => 76,
@@ -234,7 +270,7 @@ class ObjectSyntaxTest extends TestCase {
                 'friends' => ['Bar', 'Baz']
             ],
             'result' => 'Foo:76:false:Bar,Baz'
-        ], [
+            ], [
             'input'  => (object) [
                 'name' => 'Foo',
                 'age'  => 76,
@@ -243,7 +279,7 @@ class ObjectSyntaxTest extends TestCase {
             'errors' => [
                 "Error while dumping some input as Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by ':': Missing field 'is_programmer'"
             ]
-        ], [
+            ], [
             'input'  => (object) [
                 'name' => 'Foo',
                 'age'  => 'Yo',
@@ -253,7 +289,7 @@ class ObjectSyntaxTest extends TestCase {
                 "Error while dumping some input as Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by ':': Unable to dump the field 'age'",
                 "Error while dumping some input as Number: " . NumberSyntax::ERROR
             ]
-        ]]);
-
+            ]]
+        );
     }
 }

--- a/tests/ObjectSyntaxTest.php
+++ b/tests/ObjectSyntaxTest.php
@@ -11,7 +11,7 @@ use Tarsana\Syntax\StringSyntax;
 
 class ObjectSyntaxTest extends TestCase
 {
-    public function test_getters_and_setters()
+    public function test_getters_and_setters(): void
     {
         $syntax = new ObjectSyntax(['name' => S::array()], '|')
             ->fields(['name' => S::string()])
@@ -24,7 +24,7 @@ class ObjectSyntaxTest extends TestCase
         $this->assertTrue($syntax->field('age') instanceof NumberSyntax);
     }
 
-    public function test_get_nested_fields()
+    public function test_get_nested_fields(): void
     {
         $syntax = S::object(
             [
@@ -57,7 +57,7 @@ class ObjectSyntaxTest extends TestCase
         new ObjectSyntax([]);
     }
 
-    public function test_get_unknown_field()
+    public function test_get_unknown_field(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -68,7 +68,7 @@ class ObjectSyntaxTest extends TestCase
         $syntax->field('account');
     }
 
-    public function test_to_string()
+    public function test_to_string(): void
     {
         $syntax = S::object(
             [
@@ -81,7 +81,7 @@ class ObjectSyntaxTest extends TestCase
         $this->assertEqualsCompat("Object {name: String, age: Number, is_programmer: Boolean, friends: Array of (String) separated by ','} separated by ':'", "{$syntax}");
     }
 
-    public function test_parse_all_fields_are_required()
+    public function test_parse_all_fields_are_required(): void
     {
         // Parsing all required fields
         $syntax = S::object(
@@ -147,7 +147,7 @@ class ObjectSyntaxTest extends TestCase
         );
     }
 
-    public function test_parse_all_fields_are_optional()
+    public function test_parse_all_fields_are_optional(): void
     {
         // Optional Fields
         $syntax = S::object(
@@ -205,7 +205,7 @@ class ObjectSyntaxTest extends TestCase
         );
     }
 
-    public function test_parse_with_optional_fields()
+    public function test_parse_with_optional_fields(): void
     {
         $syntax = S::object(
             [
@@ -249,7 +249,7 @@ class ObjectSyntaxTest extends TestCase
         );
     }
 
-    public function test_dump()
+    public function test_dump(): void
     {
         $syntax = S::object(
             [

--- a/tests/OptionalSyntaxTest.php
+++ b/tests/OptionalSyntaxTest.php
@@ -1,33 +1,43 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\Factory as S;
 use Tarsana\Syntax\NumberSyntax;
 
-class OptionalSyntaxTest extends TestCase {
-
+class OptionalSyntaxTest extends TestCase
+{
     public function test_getters_and_setters()
     {
         $syntax = S::optional(S::string(), 'None')
             ->setDefault('...')
             ->syntax(S::number());
 
-        $this->assertEquals('...', $syntax->getDefault());
+        $this->assertEqualsCompat('...', $syntax->getDefault());
         $this->assertTrue($syntax->syntax() instanceof NumberSyntax);
     }
 
-    public function test_parse() {
-        $this->assertParse(S::optional(S::number(), 15), [
+    public function test_parse()
+    {
+        $this->assertParse(
+            S::optional(S::number(), 15),
+            [
             ['input' => '12', 'result' => 12],
             ['input' => 't56', 'result' => 15]
-        ]);
+            ]
+        );
     }
 
-    public function test_dump() {
-        $this->assertDump(S::optional(S::number(), 15), [
+    public function test_dump()
+    {
+        $this->assertDump(
+            S::optional(S::number(), 15),
+            [
             ['input' => 12, 'result' => '12'],
             ['input' => 'nan', 'errors' => [
                 'Error while dumping some input as Number: ' . NumberSyntax::ERROR
             ]],
-        ]);
+            ]
+        );
     }
 }

--- a/tests/OptionalSyntaxTest.php
+++ b/tests/OptionalSyntaxTest.php
@@ -7,7 +7,7 @@ use Tarsana\Syntax\NumberSyntax;
 
 class OptionalSyntaxTest extends TestCase
 {
-    public function test_getters_and_setters()
+    public function test_getters_and_setters(): void
     {
         $syntax = S::optional(S::string(), 'None')
             ->setDefault('...')
@@ -17,7 +17,7 @@ class OptionalSyntaxTest extends TestCase
         $this->assertTrue($syntax->syntax() instanceof NumberSyntax);
     }
 
-    public function test_parse()
+    public function test_parse(): void
     {
         $this->assertParse(
             S::optional(S::number(), 15),
@@ -28,7 +28,7 @@ class OptionalSyntaxTest extends TestCase
         );
     }
 
-    public function test_dump()
+    public function test_dump(): void
     {
         $this->assertDump(
             S::optional(S::number(), 15),

--- a/tests/StringSyntaxTest.php
+++ b/tests/StringSyntaxTest.php
@@ -7,7 +7,7 @@ use Tarsana\Syntax\StringSyntax;
 
 class StringSyntaxTest extends TestCase
 {
-    public function test_parse()
+    public function test_parse(): void
     {
         $this->assertParse(
             S::string(),
@@ -20,7 +20,7 @@ class StringSyntaxTest extends TestCase
         );
     }
 
-    public function test_dump()
+    public function test_dump(): void
     {
         $this->assertDump(
             S::string(),

--- a/tests/StringSyntaxTest.php
+++ b/tests/StringSyntaxTest.php
@@ -1,27 +1,36 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\Factory as S;
 use Tarsana\Syntax\StringSyntax;
 
-class StringSyntaxTest extends TestCase {
-
-    public function test_parse() {
-        $this->assertParse(S::string(), [
+class StringSyntaxTest extends TestCase
+{
+    public function test_parse()
+    {
+        $this->assertParse(
+            S::string(),
+            [
             ['input' => 'Lorem ?~\| ipsum/,: dolor .', 'result' => 'Lorem ?~\| ipsum/,: dolor .'],
             ['input' => '', 'errors' => [
                 "Error while parsing '' as String at character 0: " . StringSyntax::NO_EMPTY
             ]]
-        ]);
+            ]
+        );
     }
 
-    public function test_dump() {
-        $this->assertDump(S::string(), [
+    public function test_dump()
+    {
+        $this->assertDump(
+            S::string(),
+            [
             ['input' => 'Lorem ?~\| ipsum/,: dolor .', 'result' => 'Lorem ?~\| ipsum/,: dolor .'],
             ['input' => '', 'result' => ''],
             ['input' => 15, 'errors' => [
                 'Error while dumping some input as String: ' . StringSyntax::ERROR
             ]]
-        ]);
+            ]
+        );
     }
-
 }

--- a/tests/SyntaxSyntaxTest.php
+++ b/tests/SyntaxSyntaxTest.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\ArraySyntax;
 use Tarsana\Syntax\BooleanSyntax;
@@ -10,88 +12,104 @@ use Tarsana\Syntax\StringSyntax;
 use Tarsana\Syntax\Syntax;
 use Tarsana\Syntax\SyntaxSyntax;
 
-class SyntaxSyntaxTest extends TestCase {
-
-    protected function parse(string $text, String $syntax) {
-        $this->assertEquals($syntax, S::syntax()->parse($text));
+class SyntaxSyntaxTest extends TestCase
+{
+    protected function parse(string $text, string $syntax)
+    {
+        $this->assertEqualsCompat($syntax, S::syntax()->parse($text));
     }
 
-    protected function dump(Syntax $syntax, string $text) {
-        $this->assertEquals($text, S::syntax()->dump($syntax));
+    protected function dump(Syntax $syntax, string $text)
+    {
+        $this->assertEqualsCompat($text, S::syntax()->dump($syntax));
     }
 
-    public function test_string() {
+    public function test_string()
+    {
         $this->parse('', S::string());
         $this->parse('string', S::string());
         $this->parse(' string ', S::string());
         $this->dump(S::string(), 'string');
     }
 
-    public function test_optional_string() {
-        $syntax =S::optional(S::string(), 'Yo');
+    public function test_optional_string()
+    {
+        $syntax = S::optional(S::string(), 'Yo');
         $this->parse('(string:Yo)', $syntax);
         $this->dump($syntax, '(string:"Yo")');
     }
 
-    public function test_boolean() {
+    public function test_boolean()
+    {
         $this->parse('boolean', S::boolean());
         $this->dump(S::boolean(), 'boolean');
     }
 
-    public function test_optional_boolean() {
-        $syntax =S::optional(S::boolean(), false);
+    public function test_optional_boolean()
+    {
+        $syntax = S::optional(S::boolean(), false);
         $this->parse('(boolean:false)', $syntax);
         $this->dump($syntax, '(boolean:false)');
     }
 
-    public function test_number() {
+    public function test_number()
+    {
         $this->parse('number', S::number());
         $this->dump(S::number(), 'number');
     }
 
-    public function test_optional_number() {
-        $syntax =S::optional(S::number(), false);
+    public function test_optional_number()
+    {
+        $syntax = S::optional(S::number(), false);
         $this->parse('(number:false)', $syntax);
         $this->dump($syntax, '(number:false)');
     }
 
-    public function test_syntax() {
+    public function test_syntax()
+    {
         $this->parse('syntax', S::syntax());
         $this->dump(S::syntax(), 'syntax');
     }
 
-    public function test_array() {
+    public function test_array()
+    {
         $syntax = S::array();
         $this->parse('[]', $syntax);
         $this->parse('[string]', $syntax);
         $this->dump($syntax, '[string|,]');
     }
 
-    public function test_array_of_numbers() {
+    public function test_array_of_numbers()
+    {
         $syntax = S::array(S::number());
         $this->parse('[number|,]', $syntax);
         $this->dump($syntax, '[number|,]');
     }
 
-    public function test_optional_array_of_numbers() {
+    public function test_optional_array_of_numbers()
+    {
         $syntax = S::optional(S::array(S::number()), [1, 2, 3]);
         $this->parse('([number|,]:[1, 2, 3])', $syntax);
         $this->dump($syntax, '([number|,]:[1,2,3])');
     }
 
-    public function test_array_with_custom_separator() {
+    public function test_array_with_custom_separator()
+    {
         $syntax = S::array(S::number())->separator('/');
         $this->parse('[number|/]', $syntax);
         $this->dump($syntax, '[number|/]');
     }
 
-    public function test_simple_object() {
-        $syntax = S::object([
+    public function test_simple_object()
+    {
+        $syntax = S::object(
+            [
             'name' => S::string(),
             'age'  => S::number(),
             'vip'  => S::boolean(),
             'pets' => S::array()
-        ]);
+            ]
+        );
         $text = '{
             name: string,age: number,
             vip: boolean,

--- a/tests/SyntaxSyntaxTest.php
+++ b/tests/SyntaxSyntaxTest.php
@@ -24,7 +24,7 @@ class SyntaxSyntaxTest extends TestCase
         $this->assertEqualsCompat($text, S::syntax()->dump($syntax));
     }
 
-    public function test_string()
+    public function test_string(): void
     {
         $this->parse('', S::string());
         $this->parse('string', S::string());
@@ -32,46 +32,46 @@ class SyntaxSyntaxTest extends TestCase
         $this->dump(S::string(), 'string');
     }
 
-    public function test_optional_string()
+    public function test_optional_string(): void
     {
         $syntax = S::optional(S::string(), 'Yo');
         $this->parse('(string:Yo)', $syntax);
         $this->dump($syntax, '(string:"Yo")');
     }
 
-    public function test_boolean()
+    public function test_boolean(): void
     {
         $this->parse('boolean', S::boolean());
         $this->dump(S::boolean(), 'boolean');
     }
 
-    public function test_optional_boolean()
+    public function test_optional_boolean(): void
     {
         $syntax = S::optional(S::boolean(), false);
         $this->parse('(boolean:false)', $syntax);
         $this->dump($syntax, '(boolean:false)');
     }
 
-    public function test_number()
+    public function test_number(): void
     {
         $this->parse('number', S::number());
         $this->dump(S::number(), 'number');
     }
 
-    public function test_optional_number()
+    public function test_optional_number(): void
     {
         $syntax = S::optional(S::number(), false);
         $this->parse('(number:false)', $syntax);
         $this->dump($syntax, '(number:false)');
     }
 
-    public function test_syntax()
+    public function test_syntax(): void
     {
         $this->parse('syntax', S::syntax());
         $this->dump(S::syntax(), 'syntax');
     }
 
-    public function test_array()
+    public function test_array(): void
     {
         $syntax = S::array();
         $this->parse('[]', $syntax);
@@ -79,28 +79,28 @@ class SyntaxSyntaxTest extends TestCase
         $this->dump($syntax, '[string|,]');
     }
 
-    public function test_array_of_numbers()
+    public function test_array_of_numbers(): void
     {
         $syntax = S::array(S::number());
         $this->parse('[number|,]', $syntax);
         $this->dump($syntax, '[number|,]');
     }
 
-    public function test_optional_array_of_numbers()
+    public function test_optional_array_of_numbers(): void
     {
         $syntax = S::optional(S::array(S::number()), [1, 2, 3]);
         $this->parse('([number|,]:[1, 2, 3])', $syntax);
         $this->dump($syntax, '([number|,]:[1,2,3])');
     }
 
-    public function test_array_with_custom_separator()
+    public function test_array_with_custom_separator(): void
     {
         $syntax = S::array(S::number())->separator('/');
         $this->parse('[number|/]', $syntax);
         $this->dump($syntax, '[number|/]');
     }
 
-    public function test_simple_object()
+    public function test_simple_object(): void
     {
         $syntax = S::object(
             [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Syntax\UnitTests;
+<?php
+
+namespace Tarsana\Syntax\UnitTests;
 
 use Tarsana\Syntax\ArraySyntax;
 use Tarsana\Syntax\BooleanSyntax;
@@ -10,26 +12,31 @@ use Tarsana\Syntax\OptionalSyntax;
 use Tarsana\Syntax\StringSyntax;
 use Tarsana\Syntax\Syntax;
 
-class TestCase extends \PHPUnit\Framework\TestCase {
-
-    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false) {
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    public static function assertEqualsCompat($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
+    {
         if ($expected instanceof Syntax && $actual instanceof Syntax) {
-            if (get_class($expected) != get_class($actual))
+            if ($expected::class != $actual::class) {
                 throw new \Exception("'{$expected}' and '{$actual}' are not equal");
-            if ($expected instanceof StringSyntax || $expected instanceof BooleanSyntax || $expected instanceof NumberSyntax || $expected instanceof SyntaxSyntax)
+            }
+            if ($expected instanceof StringSyntax || $expected instanceof BooleanSyntax || $expected instanceof NumberSyntax || $expected instanceof SyntaxSyntax) {
                 return;
-            if ($expected instanceof OptionalSyntax)
+            }
+            if ($expected instanceof OptionalSyntax) {
                 return $this->assertEquals($expected->syntax(), $actual->syntax())
                     && $this->assertEquals($expected->getDefault(), $actual->getDefault());
-            if ($expected instanceof ArraySyntax)
+            }
+            if ($expected instanceof ArraySyntax) {
                 return $this->assertEquals($expected->syntax(), $actual->syntax())
                     && $this->assertEquals($expected->separator(), $actual->separator());
+            }
             if ($expected instanceof ObjectSyntax) {
                 $this->assertEquals(
                     array_keys($expected->fields()),
                     array_keys($actual->fields())
                 );
-                foreach($expected->fields() as $name => $syntax) {
+                foreach ($expected->fields() as $name => $syntax) {
                     $this->assertEquals($syntax, $actual->field($name));
                 }
                 return $this->assertEquals($expected->separator(), $actual->separator());
@@ -38,20 +45,23 @@ class TestCase extends \PHPUnit\Framework\TestCase {
         return parent::assertEquals($expected, $actual);
     }
 
-    protected function assertParse(Syntax $syntax, array $tests, callable $equals = null) {
-        if ($equals === null)
-            $equals = [$this, 'assertEquals'];
+    protected function assertParse(Syntax $syntax, array $tests, callable $equals = null)
+    {
+        if ($equals === null) {
+            $equals = $this->assertEqualsCompat(...);
+        }
         foreach ($tests as $test) {
             if (isset($test['result'])) {
-                if (is_string($test['input']))
+                if (is_string($test['input'])) {
                     $test['input'] = [$test['input']];
+                }
                 foreach ($test['input'] as $txt) {
                     $equals(
                         $test['result'],
                         $syntax->parse($txt)
                     );
                 }
-            } else if (isset($test['errors'])) {
+            } elseif (isset($test['errors'])) {
                 try {
                     $syntax->parse($test['input']);
                     throw new \Exception("No exception thrown for parsing '{$test['input']}' using syntax '{$syntax}'");
@@ -60,23 +70,24 @@ class TestCase extends \PHPUnit\Framework\TestCase {
                     $size   = count($errors);
                     $index  = 0;
                     while ($index < $size) {
-                        $this->assertEquals($errors[$index], "{$e->message()}");
+                        $this->assertEqualsCompat($errors[$index], "{$e->message()}");
                         $e = $e->previous();
-                        $index ++;
+                        $index++;
                     }
                 }
             }
         }
     }
 
-    protected function assertDump(Syntax $syntax, array $tests) {
+    protected function assertDump(Syntax $syntax, array $tests)
+    {
         foreach ($tests as $test) {
             if (isset($test['result'])) {
-                $this->assertEquals(
+                $this->assertEqualsCompat(
                     $test['result'],
                     $syntax->dump($test['input'])
                 );
-            } else if (isset($test['errors'])) {
+            } elseif (isset($test['errors'])) {
                 try {
                     $syntax->dump($test['input']);
                     throw new \Exception("No exception thrown for dumping '{$test['input']}' using syntax '{$syntax}'");
@@ -85,13 +96,12 @@ class TestCase extends \PHPUnit\Framework\TestCase {
                     $size   = count($errors);
                     $index  = 0;
                     while ($index < $size) {
-                        $this->assertEquals($errors[$index], "{$e->message()}");
+                        $this->assertEqualsCompat($errors[$index], "{$e->message()}");
                         $e = $e->previous();
-                        $index ++;
+                        $index++;
                     }
                 }
             }
         }
     }
-
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -45,7 +45,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         return parent::assertEquals($expected, $actual);
     }
 
-    protected function assertParse(Syntax $syntax, array $tests, callable $equals = null)
+    protected function assertParse(Syntax $syntax, array $tests, ?callable $equals = null)
     {
         if ($equals === null) {
             $equals = $this->assertEqualsCompat(...);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use Tarsana\Syntax\ObjectSyntax;
 use Tarsana\Syntax\OptionalSyntax;
 use Tarsana\Syntax\StringSyntax;
 use Tarsana\Syntax\Syntax;
+use Tarsana\Syntax\SyntaxSyntax;
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {


### PR DESCRIPTION
Code migrated to PHP 8.3 using Rector, PHPCS and manual changes.
All tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Docker-based development environment for streamlined setup

* **Chores**
  - Minimum PHP requirement raised to 8.4
  - CI matrix updated and PHPUnit upgraded to 10.5
  - Added composer scripts and developer tools for testing, linting, and automated refactoring
  - Added maintainer entry to package metadata
  - Ignoring PHPUnit cache files in repository

* **Refactor**
  - Modernized code style, type hints and test compatibility
  - Added automated refactoring configuration and simplified test runner config
<!-- end of auto-generated comment: release notes by coderabbit.ai -->